### PR TITLE
Run paper benchmark fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ benchmark: run-phenotype-only-benchmarks run-variant-benchmarks run-structural-v
 
 # Downloads the results of the 'install-tools' and 'run' targets from Zenodo, unpacks them and then runs the 'benchmark'
 # target to produce Figure 3. of the paper
-run-paper-benchmarks: install-paper-results	benchmark
+run-paper-benchmarks: download-pheval-paper-corpora install-paper-results benchmark
 
 # Download and results of the analyses run for the PheVal paper and then run the benchmark target to produce Figure 3.
 # This will download a 5.3 GB archive which will expand to ~35 GB

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,6 @@ run-paper-benchmarks: install-paper-results	benchmark
 # Download and results of the analyses run for the PheVal paper and then run the benchmark target to produce Figure 3.
 # This will download a 5.3 GB archive which will expand to ~35 GB
 install-paper-results:
+	mkdir -p $(RESULTS_DIR)
 	wget https://zenodo.org/records/14679713/files/pheval-paper-results.tar.gz -P $(TARGET)
 	tar -zxf $(TARGET)/pheval-paper-results.tar.gz --strip-components=1 -C $(RESULTS_DIR)

--- a/src/corpora/corpora.mk
+++ b/src/corpora/corpora.mk
@@ -1,6 +1,7 @@
 
 # Download the pheval paper corpora
 download-pheval-paper-corpora:
+	mkdir -p $(CORPORA_DIR)
 	wget https://zenodo.org/records/14679713/files/pheval-paper-corpora.tar.gz -P $(TARGET)
 	tar -zxf $(TARGET)/pheval-paper-corpora.tar.gz -C $(TARGET)
 	wget https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/NA12878_HG001/latest/GRCh37/HG001_GRCh37_1_22_v4.2.1_benchmark.vcf.gz  -P $(CORPORA_DIR)

--- a/src/tools/aim.mk
+++ b/src/tools/aim.mk
@@ -19,6 +19,7 @@ install-ai-marrvel: venv
 run-ai-marrvel: VENV_NAME=aim
 run-ai-marrvel: venv
 	$(PIP) install pheval.ai_marrvel==0.1.9
+	mkdir -p $(RESULTS_DIR)/$(AIM_NAME)/phenopacket_store_0.1.11_variants
 	$(VENV_BASE)/bin/pheval run --input-dir "$(AIM_DIR)" \
 		--testdata-dir "$(CORPORA_DIR)/phenopacket_store_0.1.11_variants" \
 		--output-dir "$(RESULTS_DIR)/$(AIM_NAME)/phenopacket_store_0.1.11_variants" \


### PR DESCRIPTION
* Adding missing `mkdir` statements to workflows
* Ensure corpora is downloaded in `run-paper-benchmarks`